### PR TITLE
Ignore "always on top" applications

### DIFF
--- a/source/AltTabWindow.cpp
+++ b/source/AltTabWindow.cpp
@@ -98,7 +98,7 @@ BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam) {
                 wchar_t szProcessPath[MAX_PATH];
                 if (GetModuleFileNameEx(hProcess, nullptr, szProcessPath, MAX_PATH)) {
                     std::filesystem::path filePath = szProcessPath;
-
+             
                     // Always get the title of owner window, otherwise popup window title will be displayed.
                     const int bufferSize = 256;
                     wchar_t windowTitle[bufferSize];
@@ -127,11 +127,15 @@ BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam) {
                     }
                     // If Alt+Backtick is pressed, show the process of similar process groups
                     else if (g_IsAltBacktick) {
-                        if (g_AltBacktickWndInfo.hWnd == nullptr) {
-                            g_AltBacktickWndInfo = item;
-                            AT_LOG_INFO("g_AltBacktickWndInfo: %s", WStrToUTF8(g_AltBacktickWndInfo.ProcessName).c_str());
+                        if (g_AltBacktickWndInfo.hWnd == nullptr) {            
+                            if (!(GetWindowLong(item.hWnd, GWL_EXSTYLE) & WS_EX_TOPMOST)) {
+                               g_AltBacktickWndInfo = item;
+                               AT_LOG_INFO("g_AltBacktickWndInfo: %s", WStrToUTF8(g_AltBacktickWndInfo.ProcessName).c_str());
+                            } 
                         }
-                        insert = IsSimilarProcess(g_AltBacktickWndInfo.ProcessName, item.ProcessName);
+                        if (g_AltBacktickWndInfo.hWnd != nullptr) {
+                            insert = IsSimilarProcess(g_AltBacktickWndInfo.ProcessName, item.ProcessName);
+                        }
                     }
 
                     // If the window is to be inserted, now apply the search string


### PR DESCRIPTION
Ignore "always on top" applications when looking for top-most window for alt-backtick.

Fixes https://sourceforge.net/p/alttab/tickets/16/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Alt-Tab functionality with improved window selection logic.
	- Fuzzy search added for better matching of process names and window titles.
  
- **Bug Fixes**
	- Improved error handling for process termination and window management.

These updates enhance user experience by refining window management and search capabilities within the Alt-Tab interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->