### PR TITLE
Fix startup crash

### DIFF
--- a/source/Utils.cpp
+++ b/source/Utils.cpp
@@ -748,7 +748,6 @@ bool IsTaskRunWithHighestPrivileges() {
         ExitOnFailure(hr, "Cannot get Root Folder pointer: %x", hr);
         hr = pRootFolder->CreateFolder(_bstr_t(L"\\AltTab"), _variant_t(L""), &pTaskFolder);
         if (FAILED(hr)) {
-            pRootFolder->Release();
             ExitOnFailure(hr, "Cannot create AltTab task folder: %x", hr);
         }
     }
@@ -778,6 +777,8 @@ LExit:
         pTask->Release();
     if (pRootFolder)
         pRootFolder->Release();
+    if (pTaskFolder)
+        pTaskFolder->Release();
     if (pService)
         pService->Release();
     return result;


### PR DESCRIPTION
- double release of pRootFolder caused a crash when it can't create a task folder
- wasn't releasing pTaskFolder at all.

Fixes (https://github.com/lokeshgovindu/AltTab/pull/14)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resource management to prevent potential memory leaks during task folder operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->