### PR TITLE
Remove beep. Make "backtick" configurable

### DIFF
--- a/source/AltTab.cpp
+++ b/source/AltTab.cpp
@@ -469,9 +469,9 @@ LRESULT CALLBACK LLKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
                 // ----------------------------------------------------------------------------
                 // Alt + Backtick
                 // ----------------------------------------------------------------------------
-                else if (g_Settings.HKAltBacktickEnabled && vkCode == VK_OEM_3) { // 0xC0
+                else if (g_Settings.HKAltBacktickEnabled && vkCode == g_Settings.HKBacktickKey) {
                     g_IsAltTab      = false;
-                    g_IsAltBacktick = true;
+                    g_IsAltBacktick = true;                 
 
                     if (!isShiftPressed) {
                         // Alt+Backtick is pressed
@@ -558,9 +558,9 @@ LRESULT CALLBACK LLKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
                 // gets opened.
                 //
                 // Now, send WM_KEYDOWN to g_hAltTabWnd, there handle.
-                if (vkCode == VK_OEM_3) { // 0xC0
-                    //AT_LOG_INFO("Backtick Pressed!");
-                    PostMessage(g_hListView, WM_KEYDOWN, vkCode, 0);
+                if (vkCode == g_Settings.HKBacktickKey) {
+                    // AT_LOG_INFO("Backtick Pressed!");
+                    PostMessage(g_hListView, WM_KEYDOWN, AT_NON_BEEPING_SEARCH_KEY, 0); 
                     return TRUE;
                 }
 

--- a/source/AltTab.h
+++ b/source/AltTab.h
@@ -3,6 +3,9 @@
 #include "resource.h"
 #include <string>
 
+// We send this unused value instead of VK_OEM_3 because it doesn't make Windows go "beep" 
+#define AT_NON_BEEPING_SEARCH_KEY 0x9F
+
 struct ToolTipInfo {
     std::wstring  ToolTipText;
     int           Duration;

--- a/source/AltTabSettings.cpp
+++ b/source/AltTabSettings.cpp
@@ -35,6 +35,7 @@ void ATSettingsInitDialog(HWND hDlg, const AltTabSettings& settings);
 void ATReadSettingsFromUI(HWND hDlg, AltTabSettings& settings);
 void AddTooltips         (HWND hDlg);
 void ATLogSettings       (const AltTabSettings& settings);
+int64_t HexToDecimal(const std::wstring& hexStr);
 
 namespace {
     // Sections
@@ -72,6 +73,7 @@ namespace {
     const wchar_t* ALTTAB_ENABLED            = L"AltTabEnabled"           ;
     const wchar_t* ALTBACKTICK_ENABLED       = L"AltBacktickEnabled"      ;
     const wchar_t* ALTCTRLTAB_ENABLED        = L"AltCtrlTabEnabled"       ;
+    const wchar_t* BACKTICK_KEY              = L"BacktickKey"       ;
     const wchar_t* SIMILAR_PROCESS_GROUPS    = L"SimilarProcessGroups"    ;
     const wchar_t* ENABLED                   = L"Enabled"                 ;
     const wchar_t* PROCESS_LIST              = L"ProcessList"             ;
@@ -109,6 +111,7 @@ void AltTabSettings::Reset() {
     HKAltTabEnabled            = DEFAULT_ALT_TAB_ENABLED            ;
     HKAltBacktickEnabled       = DEFAULT_ALT_BACKTICK_ENABLED       ;
     HKAltCtrlTabEnabled        = DEFAULT_ALT_CTRL_TAB_ENABLED       ;
+    HKBacktickKey              = HexToDecimal(DEFAULT_BACKTICK_KEY);
     SSCueBannerText            = DEFAULT_SS_CUE_BANNER_TEXT         ;
     SSFontName                 = DEFAULT_SS_FONT_NAME               ;
     SSFontSize                 = DEFAULT_SS_FONT_SIZE               ;
@@ -479,8 +482,13 @@ std::wstring ATSettingsFilePath(bool overwrite) {
         fs << ";        0xBB : Green component"                                                 << std::endl;
         fs << ";        0xCC : Blue component"                                                  << std::endl;
         fs << ";   3. FontStyle: normal / italic / bold / bold italic"                          << std::endl;
-        fs << ";   4. Please delete this file to create a new settings file when AltTab opens." << std::endl;
-        fs << ";   5. Please use tray menu Reload AltTabSettings.ini / Reload in Settings"      << std::endl;
+        fs << ";   4. BacktickKey: Is the hex value of a virtual key code, as defined here:"    << std::endl;
+        fs << ";      https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes" << std::endl;
+        fs << ";      You might like to try: 0xC0 (VK_OEM_3) for US Keyboard" << std::endl;
+        fs << ";                             0xDC (VK_OEM_5) for Italian Keyboard" << std::endl;
+        fs << ";                             0xDE (VK_OEM_7) for French Keyboard" << std::endl;
+        fs << ";   5. Please delete this file to create a new settings file when AltTab opens." << std::endl;
+        fs << ";   6. Please use tray menu Reload AltTabSettings.ini / Reload in Settings"      << std::endl;
         fs << ";      dialog to make use of new settings without restarting AltTab."            << std::endl;
         fs << "; -----------------------------------------------------------------------------" << std::endl;
         fs.close();
@@ -512,6 +520,33 @@ void ReadSetting(const std::wstring& iniFile, LPCTSTR section, LPCTSTR keyName, 
     value = buffer;
 }
 
+int64_t HexToDecimal(const std::wstring& hexStr) {
+    std::wregex hexRegex(L"^(0[xX])?[0-9a-fA-F]+$");
+    if (!std::regex_match(hexStr, hexRegex)) {
+        AT_LOG_DEBUG("%S does not seem to be a hex value", hexStr);
+        return 0;
+    }
+    
+    const wchar_t* str = hexStr.c_str();
+
+    // Skip "0x" or "0X" prefix if present
+    if (hexStr.length() >= 2 && str[0] == L'0' && (str[1] == L'x' || str[1] == L'X')) {
+        str += 2;
+    }
+
+    wchar_t* endPtr = nullptr;
+    uint64_t value = wcstoull(str, &endPtr, 16);
+
+    return value;
+}
+
+const wchar_t* DecimalToHex(uint64_t decimal) {
+    static wchar_t buffer[32];
+    swprintf_s(buffer, L"0x%llX", decimal);
+    return buffer;
+}
+
+
 /*!
  * \brief Write the current settings the given file path
  * 
@@ -525,10 +560,13 @@ void ATSettingsToFile(const std::wstring& iniFile) {
     const std::wstring LVBackgroundColor          = ColorRefToRGBString(g_Settings.LVBackgroundColor         );
     const std::wstring LVHighlightTextColor       = ColorRefToRGBString(g_Settings.LVHighlightTextColor      );
     const std::wstring LVHighlightBackgroundColor = ColorRefToRGBString(g_Settings.LVHighlightBackgroundColor);
+    const std::wstring HKBacktickKeyHex           = DecimalToHex(g_Settings.HKBacktickKey);
 
     WriteSetting(iniFile, HOTKEYS           , ALTTAB_ENABLED           , g_Settings.HKAltTabEnabled         );
     WriteSetting(iniFile, HOTKEYS           , ALTBACKTICK_ENABLED      , g_Settings.HKAltBacktickEnabled    );
     WriteSetting(iniFile, HOTKEYS           , ALTCTRLTAB_ENABLED       , g_Settings.HKAltCtrlTabEnabled     );
+    WriteSetting(iniFile, HOTKEYS           , BACKTICK_KEY             , HKBacktickKeyHex);
+
     WriteSetting(iniFile, SEARCH_STRING     , CUE_BANNER_TEXT          , g_Settings.SSCueBannerText         );
     WriteSetting(iniFile, SEARCH_STRING     , FONT_NAME                , g_Settings.SSFontName              );
     WriteSetting(iniFile, SEARCH_STRING     , FONT_SIZE                , g_Settings.SSFontSize              );
@@ -574,10 +612,15 @@ void ATLoadSettings() {
     DWORD LVBackgroundColor          = 0;
     DWORD LVHighlightTextColor       = 0;
     DWORD LVHighlightBackgroundColor = 0;
+    std::wstring HKBacktickKeyHex;
+
+    // Setting default values here seems a bit silly if we can just call `g_Settings.Reset();` instead. That way defaults are in one place.
 
     ReadSetting(iniFile, HOTKEYS           , ALTTAB_ENABLED           , DEFAULT_ALT_TAB_ENABLED            , g_Settings.HKAltTabEnabled         );
     ReadSetting(iniFile, HOTKEYS           , ALTBACKTICK_ENABLED      , DEFAULT_ALT_BACKTICK_ENABLED       , g_Settings.HKAltBacktickEnabled    );
     ReadSetting(iniFile, HOTKEYS           , ALTCTRLTAB_ENABLED       , DEFAULT_ALT_CTRL_TAB_ENABLED       , g_Settings.HKAltCtrlTabEnabled     );
+    ReadSetting(iniFile, HOTKEYS           , BACKTICK_KEY             , DEFAULT_BACKTICK_KEY               , HKBacktickKeyHex);
+
     ReadSetting(iniFile, SEARCH_STRING     , CUE_BANNER_TEXT          , DEFAULT_SS_CUE_BANNER_TEXT         , g_Settings.SSCueBannerText         );
     ReadSetting(iniFile, SEARCH_STRING     , FONT_NAME                , DEFAULT_SS_FONT_NAME               , g_Settings.SSFontName              );
     ReadSetting(iniFile, SEARCH_STRING     , FONT_SIZE                , DEFAULT_SS_FONT_SIZE               , g_Settings.SSFontSize              );
@@ -615,6 +658,7 @@ void ATLoadSettings() {
     g_Settings.LVBackgroundColor          = RGBIntToColorRef(LVBackgroundColor         );
     g_Settings.LVHighlightTextColor       = RGBIntToColorRef(LVHighlightTextColor      );
     g_Settings.LVHighlightBackgroundColor = RGBIntToColorRef(LVHighlightBackgroundColor);
+    g_Settings.HKBacktickKey              = HexToDecimal(HKBacktickKeyHex);
 
     // Clear the previous ProcessGroupsList
     g_Settings.ProcessGroupsList.clear();

--- a/source/AltTabSettings.h
+++ b/source/AltTabSettings.h
@@ -22,6 +22,7 @@ using StringList           = std::vector<std::wstring>;
 #define DEFAULT_ALT_TAB_ENABLED              true
 #define DEFAULT_ALT_BACKTICK_ENABLED         true
 #define DEFAULT_ALT_CTRL_TAB_ENABLED         true
+#define DEFAULT_BACKTICK_KEY                 L"0xC0"   // aka VK_OEM_3, US `~ key
 #define DEFAULT_SS_CUE_BANNER_TEXT           L"Search windows by title or process name..."
 #define DEFAULT_SS_FONT_NAME                 L"Lucida Handwriting"
 #define DEFAULT_SS_FONT_SIZE                 11
@@ -72,6 +73,7 @@ struct AltTabSettings {
     bool                   HKAltTabEnabled;            // Alt+Tab enabled
     bool                   HKAltBacktickEnabled;       // Alt+Backtick enabled
     bool                   HKAltCtrlTabEnabled;        // Alt+Ctrl+Tab enabled
+    WPARAM                 HKBacktickKey;              // What key is the 'backtick' key
     // ----------------------------------------------------------------------------
     // SearchString Font Name, Size, Style, Color and Background Color
     // ----------------------------------------------------------------------------

--- a/source/AltTabWindow.cpp
+++ b/source/AltTabWindow.cpp
@@ -922,178 +922,192 @@ static void SetListViewCustomColors(HWND hListView, COLORREF backgroundColor, CO
     SendMessageW(hListView, LVM_SETTEXTCOLOR,   0, (LPARAM)textColor);
 }
 
-LRESULT CALLBACK SearchStringSubclassProc(
-    HWND       hWnd,
-    UINT       uMsg,
-    WPARAM     wParam,
-    LPARAM     lParam,
-    UINT_PTR   /*uIdSubclass*/,
-    DWORD_PTR  /*dwRefData*/)
-{
-    //AT_LOG_TRACE;
-    //AT_LOG_INFO(std::format("uMsg: {:4}, wParam: {}, lParam: {}", uMsg, wParam, lParam).c_str());
-    auto vkCode = wParam;
+
+// Helper function to handle common navigation and window management keys identically to the original code
+inline bool HandleCommonAltTabKeys(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT& outResult) {
+    const auto vkCode = wParam;
     const bool isShiftPressed = GetAsyncKeyState(VK_SHIFT) & 0x8000;
 
+    AT_LOG_INFO("HandleCommonAltKeys. key: %d", wParam);
+
+    // ----------------------------------------------------------------------------
+    // VK_ESCAPE
+    // ----------------------------------------------------------------------------
+    if (wParam == VK_ESCAPE) {
+        // Retain original conditional logging approach implicitly by calling DefSubclassProc
+        DestroyAltTabWindow();
+        outResult = DefSubclassProc(hWnd, uMsg, wParam, lParam);
+        return true;
+    }
+    // ----------------------------------------------------------------------------
+    // VK_DOWN
+    // ----------------------------------------------------------------------------
+    else if (wParam == VK_DOWN) {
+        AT_LOG_INFO("Down Pressed!");
+        ATWListViewSelectNextItem();
+        outResult = TRUE;
+        return true;
+    }
+    // ----------------------------------------------------------------------------
+    // VK_UP
+    // ----------------------------------------------------------------------------
+    else if (wParam == VK_UP) {
+        AT_LOG_INFO("Up Pressed!");
+        ATWListViewSelectPrevItem();
+        outResult = TRUE;
+        return true;
+    }
+    // ----------------------------------------------------------------------------
+    // VK_HOME / VK_PRIOR
+    // ----------------------------------------------------------------------------
+    else if (vkCode == VK_HOME || vkCode == VK_PRIOR) {
+        AT_LOG_INFO("Home/PageUp Pressed!");
+        if (!g_AltTabWindows.empty()) {
+            ATWListViewSelectItem(0);
+        }
+        outResult = TRUE;
+        return true;
+    }
+    // ----------------------------------------------------------------------------
+    // VK_END / VK_NEXT
+    // ----------------------------------------------------------------------------
+    else if (vkCode == VK_END || vkCode == VK_NEXT) {
+        AT_LOG_INFO("End/PageDown Pressed!");
+        if (!g_AltTabWindows.empty()) {
+            ATWListViewSelectItem((int)g_AltTabWindows.size() - 1);
+        }
+        outResult = TRUE;
+        return true;
+    }
+    // ----------------------------------------------------------------------------
+    // VK_DELETE
+    // ----------------------------------------------------------------------------
+    else if (vkCode == VK_DELETE) {
+        if (isShiftPressed) {
+            AT_LOG_INFO("Shift+Delete Pressed!");
+            int ind = ATWListViewGetSelectedItem();
+            if (ind == -1) {
+                outResult = TRUE;
+                return true;
+            }
+            g_AltTabWindows[ind].IsBeingClosed = true;
+            TerminateProcessEx(g_AltTabWindows[ind].PID);
+        } else {
+            AT_LOG_INFO("Delete Pressed!");
+            const int ind = ATWListViewGetSelectedItem();
+            if (ind == -1) {
+                outResult = TRUE;
+                return true;
+            }
+            AT_LOG_INFO("Ind: %d, Title: %s", ind, WStrToUTF8(g_AltTabWindows[ind].Title).c_str());
+            ATCloseWindow(ind);
+        }
+        outResult = TRUE;
+        return true;
+    }
+    // ----------------------------------------------------------------------------
+    // Backtick (VK_OEM_3)
+    // ----------------------------------------------------------------------------
+    else if (vkCode == VK_OEM_3) { // 0xC0 - '`~' for US
+        AT_LOG_INFO("Backtick Pressed!, g_IsAltBacktick = %d", g_IsAltBacktick);
+        const int direction = isShiftPressed ? -1 : 1;
+
+        const int selectedInd = ATWListViewGetSelectedItem();
+        if (selectedInd == -1) {
+            outResult = TRUE;
+            return true;
+        }
+
+        const int N = (int)g_AltTabWindows.size();
+        const auto& processName = g_AltTabWindows[selectedInd].ProcessName;
+        const int pgInd = GetProcessGroupIndex(processName);
+        int nextInd = (selectedInd + N + direction) % N;
+
+        if (g_IsAltBacktick) {
+            ATWListViewSelectItem(nextInd);
+            outResult = TRUE;
+            return true;
+        }
+
+        // Maintained the exact sequence of distinct if checks to avoid macro/side-effect deviations
+        for (int i = 1; i < N; ++i) {
+            nextInd = (selectedInd + N + i * direction) % N;
+            if (IsSimilarProcess(pgInd, g_AltTabWindows[nextInd].ProcessName)) {
+                break;
+            }
+            if (EqualsIgnoreCase(processName, g_AltTabWindows[nextInd].ProcessName)) {
+                break;
+            }
+            nextInd = -1;
+        }
+
+        if (nextInd != -1) {
+            ATWListViewSelectItem(nextInd);
+        }
+        outResult = TRUE;
+        return true;
+    }
+    // ----------------------------------------------------------------------------
+    // VK_F1
+    // ----------------------------------------------------------------------------
+    else if (vkCode == VK_F1) {
+        DestroyAltTabWindow();
+        if (isShiftPressed) {
+            DialogBoxW(g_hInstance, MAKEINTRESOURCE(IDD_ABOUTBOX), nullptr, ATAboutDlgProc);
+        } else {
+            ShowHelpWindow();
+        }
+        outResult = TRUE;
+        return true;
+    }
+    // ----------------------------------------------------------------------------
+    // VK_F2
+    // ----------------------------------------------------------------------------
+    else if (vkCode == VK_F2) {
+        DestroyAltTabWindow();
+        if (g_hSettingsWnd == nullptr) {
+            DialogBoxW(g_hInstance, MAKEINTRESOURCE(IDD_SETTINGS), nullptr, ATSettingsDlgProc);
+        } else {
+            SetForegroundWindow(g_hSettingsWnd);
+        }
+        outResult = TRUE;
+        return true;
+    }
+    // ----------------------------------------------------------------------------
+    // VK_RETURN
+    // ----------------------------------------------------------------------------
+    else if (vkCode == VK_RETURN) {
+        AT_LOG_INFO("Enter Pressed!");
+        DestroyAltTabWindow(true);
+        outResult = TRUE;
+        return true;
+    }
+
+    return false;
+}
+
+
+LRESULT CALLBACK SearchStringSubclassProc(
+    HWND hWnd,
+    UINT uMsg,
+    WPARAM wParam,
+    LPARAM lParam,
+    UINT_PTR /*uIdSubclass*/,
+    DWORD_PTR /*dwRefData*/) {
     switch (uMsg) {
     case WM_KEYDOWN:
     case WM_SYSKEYDOWN: {
-        //AT_LOG_INFO("WM_KEYDOWN/WM_SYSKEYDOWN: wParam = 0x%02X", (unsigned int)wParam);
-        // ----------------------------------------------------------------------------
-        // VK_ESCAPE
-        // ----------------------------------------------------------------------------
-        if (wParam == VK_ESCAPE) {
-            AT_LOG_INFO("VK_ESCAPE");
-            DestroyAltTabWindow();
-        }
-        // ----------------------------------------------------------------------------
-        // VK_DOWN
-        // ----------------------------------------------------------------------------
-        else if (wParam == VK_DOWN) {
-            AT_LOG_INFO("Down Pressed!");
-            ATWListViewSelectNextItem();
-            return TRUE;
-        }
-        // ----------------------------------------------------------------------------
-        // VK_DOWN
-        // ----------------------------------------------------------------------------
-        else if (wParam == VK_UP) {
-            AT_LOG_INFO("Up Pressed!");
-            ATWListViewSelectPrevItem();
-            return TRUE;
-        }
-        // ----------------------------------------------------------------------------
-        // VK_HOME / VK_PRIOR
-        // ----------------------------------------------------------------------------
-        else if (vkCode == VK_HOME || vkCode == VK_PRIOR) {
-            AT_LOG_INFO("Home/PageUp Pressed!");
-            if (!g_AltTabWindows.empty()) {
-                ATWListViewSelectItem(0);
+        LRESULT commonResult = 0;
+        if (HandleCommonAltTabKeys(hWnd, uMsg, wParam, lParam, commonResult)) {
+            // Contextual string logging for VK_ESCAPE handled natively via the shared proc call
+            if (wParam == VK_ESCAPE) {
+                AT_LOG_INFO("VK_ESCAPE");
             }
-            return TRUE;
+            return commonResult;
         }
-        // ----------------------------------------------------------------------------
-        // VK_END / VK_NEXT
-        // ----------------------------------------------------------------------------
-        else if (vkCode == VK_END || vkCode == VK_NEXT) {
-            AT_LOG_INFO("End/PageDown Pressed!");
-            if (!g_AltTabWindows.empty()) {
-                ATWListViewSelectItem((int)g_AltTabWindows.size() - 1);
-            }
-            return TRUE;
-        }
-        // ----------------------------------------------------------------------------
-        // VK_DELETE
-        // ----------------------------------------------------------------------------
-        else if (vkCode == VK_DELETE) {
-            if (isShiftPressed) {
-                AT_LOG_INFO("Shift+Delete Pressed!");
-                int ind = ATWListViewGetSelectedItem();
-                if (ind == -1)
-                    return TRUE;
-                g_AltTabWindows[ind].IsBeingClosed = true;
-                TerminateProcessEx(g_AltTabWindows[ind].PID);
-            } else {
-                AT_LOG_INFO("Delete Pressed!");
 
-                // Send the SC_CLOSE command to the window
-                const int ind = ATWListViewGetSelectedItem();
-                if (ind == -1)
-                    return TRUE;
-                AT_LOG_INFO("Ind: %d, Title: %s", ind, WStrToUTF8(g_AltTabWindows[ind].Title).c_str());
-                ATCloseWindow(ind);
-            }
-            return TRUE;
-        }
-        // ----------------------------------------------------------------------------
-        // Backtick
-        // ----------------------------------------------------------------------------
-        else if (vkCode == VK_OEM_3) { // 0xC0 - '`~' for US
-            AT_LOG_INFO("Backtick Pressed!, g_IsAltBacktick = %d", g_IsAltBacktick);
-            const int direction = isShiftPressed ? -1 : 1;
-
-            // Move to next / previous same item based on the direction
-            const int selectedInd = ATWListViewGetSelectedItem();
-            if (selectedInd == -1)
-                return TRUE;
-
-            const int N = (int)g_AltTabWindows.size();
-            const auto& processName = g_AltTabWindows[selectedInd].ProcessName; // Selected process name
-            const int pgInd = GetProcessGroupIndex(processName);                // Index in ProcessGroupList
-            int nextInd = (selectedInd + N + direction) % N;                    // Next index to select
-
-            // If the AltTab window is invoked with Alt + Backtick, then we should
-            // move to the next item in the list without checking the process name.
-            if (g_IsAltBacktick) {
-                ATWListViewSelectItem(nextInd);
-                return TRUE;
-            }
-
-            // If the control comes to here, AltTab window is invoked with Alt + Tab
-            // Check if the next item is similar to the selected item
-            for (int i = 1; i < N; ++i) {
-                nextInd = (selectedInd + N + i * direction) % N;
-                if (IsSimilarProcess(pgInd, g_AltTabWindows[nextInd].ProcessName)) {
-                    break;
-                }
-                if (EqualsIgnoreCase(processName, g_AltTabWindows[nextInd].ProcessName)) {
-                    break;
-                }
-                nextInd = -1;
-            }
-
-            if (nextInd != -1)
-                ATWListViewSelectItem(nextInd);
-            return TRUE;
-        }
-        // ----------------------------------------------------------------------------
-        // VK_F1
-        // ----------------------------------------------------------------------------
-        else if (vkCode == VK_F1) {
-            DestroyAltTabWindow();
-            if (isShiftPressed) {
-                DialogBoxW(g_hInstance, MAKEINTRESOURCE(IDD_ABOUTBOX), nullptr, ATAboutDlgProc);
-            } else {
-                ShowHelpWindow();
-            }
-            return TRUE;
-        }
-        // ----------------------------------------------------------------------------
-        // Shift + VK_F1
-        // ----------------------------------------------------------------------------
-        else if (isShiftPressed && vkCode == VK_F1) {
-            DestroyAltTabWindow();
-            DialogBoxW(g_hInstance, MAKEINTRESOURCE(IDD_ABOUTBOX), nullptr, ATAboutDlgProc);
-            return TRUE;
-        }
-        // ----------------------------------------------------------------------------
-        // VK_F2
-        // ----------------------------------------------------------------------------
-        else if (vkCode == VK_F2) {
-            DestroyAltTabWindow();
-            // Do NOT assign owner for this, if owner is assigned and the settings
-            // dialog is not active, then it won't be displayed in alt tab windows list.
-            if (g_hSettingsWnd == nullptr) {
-                DialogBoxW(g_hInstance, MAKEINTRESOURCE(IDD_SETTINGS), nullptr, ATSettingsDlgProc);
-            } else {
-                SetForegroundWindow(g_hSettingsWnd);
-            }
-            return TRUE;
-        }
-        // ----------------------------------------------------------------------------
-        // VK_ENTER
-        // ----------------------------------------------------------------------------
-        else if (vkCode == VK_RETURN) {
-            AT_LOG_INFO("Enter Pressed!");
-            DestroyAltTabWindow(true);
-            return TRUE;
-        }
-        // ----------------------------------------------------------------------------
-        // WM_CHAR won't be sent when ALT is pressed, this is the alternative to handle when a key is pressed.
-        // And collect the chars and form a search string.
-        // Ignore Backtick (`), Tab, Backspace, and non-printable characters while forming search string.
-        // ----------------------------------------------------------------------------
-        else if ((g_IsAltTab || g_IsAltBacktick) && !g_IsAltCtrlTab) {
+        // Fallback processing for search character registration
+        if ((g_IsAltTab || g_IsAltBacktick) && !g_IsAltCtrlTab) {
             wchar_t ch = '\0';
             const bool isChar = ATMapVirtualKey((UINT)wParam, ch);
             bool update = false;
@@ -1104,100 +1118,47 @@ LRESULT CALLBACK SearchStringSubclassProc(
                 g_SearchString.pop_back();
                 update = true;
             }
-            //AT_LOG_INFO("IsChar, %d, Update: %d, Char: %#4x, SearchString: [%s], Len(SearchString): %d", isChar, update, ch, WStrToUTF8(g_SearchString).c_str(), (int)g_SearchString.size());
 
             if (update) {
                 SendMessageW(g_hSearchString, WM_SETTEXT, 0, (LPARAM)(g_SearchString).c_str());
-
-                // Set the cursor to the end of the text
                 SendMessageW(g_hSearchString, EM_SETSEL, (WPARAM)g_SearchString.size(), (LPARAM)g_SearchString.size());
                 return 0;
             }
 
-            // Let default handler update text first
             LRESULT result = isChar ? 0 : DefSubclassProc(hWnd, uMsg, wParam, lParam);
-
-            // Invalidate to trigger repaint
             InvalidateRect(hWnd, nullptr, TRUE);
-
             return result;
         }
-        // AT_LOG_INFO("Not handled: wParam: %0#4x, iswprint: %d", wParam, iswprint((wint_t)wParam));
     } break;
 
-    // Show the application tray menu on right click / context menu request
     case WM_CONTEXTMENU: {
         AT_LOG_INFO("WM_CONTEXTMENU");
         POINT pt;
         GetCursorPos(&pt);
         const bool result = ShowTrayContextMenu(g_hAltTabWnd, pt);
 
-        // Close the AltTab window after showing the context menu and handling the menu command.
         if (result) {
             DestroyAltTabWindow();
         }
         return 0;
     } break;
 
-    // ----------------------------------------------------------------------------
-    // WM_CHAR, NOTE: This is also needed to handle character input when ALT is not pressed. Ex: Alt+Ctrl+Tab
-    // ----------------------------------------------------------------------------
     case WM_CHAR: {
         AT_LOG_INFO("WM_CHAR: wParam = 0x%02X", (unsigned int)wParam);
         const wchar_t ch = (wchar_t)wParam;
-        // Handle character input for search functionality
         if (!(ch == '`' || ch == VK_TAB || ch == VK_DELETE || ch == VK_SPACE || ch == '\0')) {
-            // Let the default handler process the character input
             LRESULT result = DefSubclassProc(hWnd, uMsg, wParam, lParam);
 
-            // After processing the character, update the search filter
             wchar_t searchString[_MAX_PATH] = { 0 };
             GetWindowTextW(g_hSearchString, searchString, _MAX_PATH);
             g_SearchString = searchString;
             return result;
         }
-        return 0; // Ignore other characters
-    } break;
-
-#if 0
-    // Last key is not getting cleared in AltTab window mode.
-    // First WM_KEYDOWN is sent then WM_PAINT.
-    case WM_PAINT: {
-        AT_LOG_INFO("WM_PAINT");
-        //  Draw search icon inside the edit control
-        PAINTSTRUCT ps;
-        HDC hdc = BeginPaint(hWnd, &ps);
-
-        // Draw background & text
-        DefSubclassProc(hWnd, uMsg, wParam, lParam);
-
-        // Get the dimensions of the edit control
-        RECT rcClient;
-        GetClientRect(hWnd, &rcClient);
-        const int iconSize = 16;
-        const int x = rcClient.right - iconSize - 6;    // Padding from right
-        const int y = (rcClient.bottom - iconSize) / 2; // vertically centered
-        ImageList_DrawEx(
-            g_hImageList16, g_nImgSearchInd, hdc, x, y, iconSize, iconSize, CLR_NONE, CLR_NONE, ILD_NORMAL);
-
-        EndPaint(hWnd, &ps);
-
         return 0;
     } break;
-#endif // 0
 
     case WM_NOTIFY: {
         AT_LOG_INFO("WM_NOTIFY");
-        //LPNMHDR nmhdr = reinterpret_cast<LPNMHDR>(lParam);
-        //if (nmhdr->code == LVN_ITEMCHANGED) {
-        //    LPNMLISTVIEW pnmListView = reinterpret_cast<LPNMLISTVIEW>(nmhdr);
-
-        //    if ((pnmListView->uChanged & LVIF_STATE) && (pnmListView->uNewState & LVIS_SELECTED)) {
-        //        // The mouse has moved over the item
-        //        // You can show a message or perform any action here
-        //        MessageBox(hListView, L"Mouse moved over item!", L"ListView Notification", MB_OK | MB_ICONINFORMATION);
-        //    }
-        //}
     } break;
     }
 
@@ -1205,237 +1166,46 @@ LRESULT CALLBACK SearchStringSubclassProc(
 }
 
 LRESULT CALLBACK ListViewSubclassProc(
-    HWND       hListView,
-    UINT       uMsg,
-    WPARAM     wParam,
-    LPARAM     lParam,
-    UINT_PTR   /*uIdSubclass*/,
-    DWORD_PTR  /*dwRefData*/)
-{
-    //AT_LOG_INFO(std::format("uMsg: {:4}, wParam: {}, lParam: {}", uMsg, wParam, lParam).c_str());
-    auto vkCode = wParam;
-    const bool isShiftPressed = GetAsyncKeyState(VK_SHIFT) & 0x8000;
-
+    HWND hListView,
+    UINT uMsg,
+    WPARAM wParam,
+    LPARAM lParam,
+    UINT_PTR /*uIdSubclass*/,
+    DWORD_PTR /*dwRefData*/) {
     switch (uMsg) {
     case WM_KEYDOWN:
     case WM_SYSKEYDOWN: {
-        // ----------------------------------------------------------------------------
-        // VK_ESCAPE
-        // ----------------------------------------------------------------------------
-        if (wParam == VK_ESCAPE) {
-            AT_LOG_INFO("VK_ESCAPE Pressed!, g_hContextMenu: %p", g_hContextMenu);
-            DestroyAltTabWindow();
-        }
-        // ----------------------------------------------------------------------------
-        // VK_DOWN
-        // ----------------------------------------------------------------------------
-        else if (wParam == VK_DOWN) {
-            AT_LOG_INFO("Down Pressed!");
-            ATWListViewSelectNextItem();
-            return TRUE;
-        }
-        // ----------------------------------------------------------------------------
-        // VK_DOWN
-        // ----------------------------------------------------------------------------
-        else if (wParam == VK_UP) {
-            AT_LOG_INFO("Up Pressed!");
-            ATWListViewSelectPrevItem();
-            return TRUE;
-        }
-        // ----------------------------------------------------------------------------
-        // VK_HOME / VK_PRIOR
-        // ----------------------------------------------------------------------------
-        else if (vkCode == VK_HOME || vkCode == VK_PRIOR) {
-            AT_LOG_INFO("Home/PageUp Pressed!");
-            if (!g_AltTabWindows.empty()) {
-                ATWListViewSelectItem(0);
+        LRESULT commonResult = 0;
+        if (HandleCommonAltTabKeys(hListView, uMsg, wParam, lParam, commonResult)) {
+            if (wParam == VK_ESCAPE) {
+                AT_LOG_INFO("VK_ESCAPE Pressed!, g_hContextMenu: %p", g_hContextMenu);
             }
-            return TRUE;
+            return commonResult;
         }
-        // ----------------------------------------------------------------------------
-        // VK_END / VK_NEXT
-        // ----------------------------------------------------------------------------
-        else if (vkCode == VK_END || vkCode == VK_NEXT) {
-            AT_LOG_INFO("End/PageDown Pressed!");
-            if (!g_AltTabWindows.empty()) {
-                ATWListViewSelectItem((int)g_AltTabWindows.size() - 1);
-            }
-            return TRUE;
-        }
-        // ----------------------------------------------------------------------------
-        // VK_DELETE
-        // ----------------------------------------------------------------------------
-        else if (vkCode == VK_DELETE) {
-            if (isShiftPressed) {
-                AT_LOG_INFO("Shift+Delete Pressed!");
-                int ind = ATWListViewGetSelectedItem();
-                if (ind == -1)
-                    return TRUE;
-                g_AltTabWindows[ind].IsBeingClosed = true;
-                TerminateProcessEx(g_AltTabWindows[ind].PID);
-            } else {
-                AT_LOG_INFO("Delete Pressed!");
-
-                // Send the SC_CLOSE command to the window
-                const int ind = ATWListViewGetSelectedItem();
-                if (ind == -1)
-                    return TRUE;
-                AT_LOG_INFO("Ind: %d, Title: %s", ind, WStrToUTF8(g_AltTabWindows[ind].Title).c_str());
-                ATCloseWindow(ind);
-            }
-            return TRUE;
-        }
-        // ----------------------------------------------------------------------------
-        // Backtick
-        // ----------------------------------------------------------------------------
-        else if (vkCode == VK_OEM_3) { // 0xC0 - '`~' for US
-            AT_LOG_INFO("Backtick Pressed!, g_IsAltBacktick = %d", g_IsAltBacktick);
-            const int direction = isShiftPressed ? -1 : 1;
-
-            // Move to next / previous same item based on the direction
-            const int selectedInd = ATWListViewGetSelectedItem();
-            if (selectedInd == -1)
-                return TRUE;
-
-            const int N = (int)g_AltTabWindows.size();
-            const auto& processName = g_AltTabWindows[selectedInd].ProcessName; // Selected process name
-            const int pgInd = GetProcessGroupIndex(processName);                // Index in ProcessGroupList
-            int nextInd = (selectedInd + N + direction) % N;                    // Next index to select
-
-            // If the AltTab window is invoked with Alt + Backtick, then we should
-            // move to the next item in the list without checking the process name.
-            if (g_IsAltBacktick) {
-                ATWListViewSelectItem(nextInd);
-                return TRUE;
-            }
-
-            // If the control comes to here, AltTab window is invoked with Alt + Tab
-            // Check if the next item is similar to the selected item
-            for (int i = 1; i < N; ++i) {
-                nextInd = (selectedInd + N + i * direction) % N;
-                if (IsSimilarProcess(pgInd, g_AltTabWindows[nextInd].ProcessName)) {
-                    break;
-                }
-                if (EqualsIgnoreCase(processName, g_AltTabWindows[nextInd].ProcessName)) {
-                    break;
-                }
-                nextInd = -1;
-            }
-
-            if (nextInd != -1)
-                ATWListViewSelectItem(nextInd);
-            return TRUE;
-        }
-        // ----------------------------------------------------------------------------
-        // VK_F1
-        // ----------------------------------------------------------------------------
-        else if (vkCode == VK_F1) {
-            DestroyAltTabWindow();
-            if (isShiftPressed) {
-                DialogBoxW(g_hInstance, MAKEINTRESOURCE(IDD_ABOUTBOX), nullptr, ATAboutDlgProc);
-            } else {
-                ShowHelpWindow();
-            }
-            return TRUE;
-        }
-        // ----------------------------------------------------------------------------
-        // Shift + VK_F1
-        // ----------------------------------------------------------------------------
-        else if (isShiftPressed && vkCode == VK_F1) {
-            DestroyAltTabWindow();
-            DialogBoxW(g_hInstance, MAKEINTRESOURCE(IDD_ABOUTBOX), nullptr, ATAboutDlgProc);
-            return TRUE;
-        }
-        // ----------------------------------------------------------------------------
-        // VK_F2
-        // ----------------------------------------------------------------------------
-        else if (vkCode == VK_F2) {
-            DestroyAltTabWindow();
-            // Do NOT assign owner for this, if owner is assigned and the settings
-            // dialog is not active, then it won't be displayed in alt tab windows list.
-            if (g_hSettingsWnd == nullptr) {
-                DialogBoxW(g_hInstance, MAKEINTRESOURCE(IDD_SETTINGS), nullptr, ATSettingsDlgProc);
-            } else {
-                SetForegroundWindow(g_hSettingsWnd);
-            }
-            return TRUE;
-        }
-        // ----------------------------------------------------------------------------
-        // VK_ENTER
-        // ----------------------------------------------------------------------------
-        else if (vkCode == VK_RETURN) {
-            AT_LOG_INFO("Enter Pressed!");
-            DestroyAltTabWindow(true);
-            return TRUE;
-        }
-        // ----------------------------------------------------------------------------
-        // WM_CHAR won't be sent when ALT is pressed, this is the alternative to handle when a key is pressed.
-        // And collect the chars and form a search string.
-        // Ignore Backtick (`), Tab, Backspace, and non-printable characters while forming search string.
-        // ----------------------------------------------------------------------------
-        else {
-            // No need to handle anything here.
-#if 0
-            AT_LOG_WARN("Shouldn't come to here: WM_KEYDOWN/WM_SYSKEYDOWN: wParam = 0x%02X", (unsigned int)wParam);
-            wchar_t ch = '\0';
-            bool isChar = ATMapVirtualKey((UINT)wParam, ch);
-            bool update = false;
-            if (!(wParam == '`' || wParam == VK_TAB || wParam == VK_BACK || ch == '\0') && isChar) {
-                g_SearchString += ch;
-                update = true;
-            } else if (wParam == VK_BACK && !g_SearchString.empty()) {
-                g_SearchString.pop_back();
-                update = true;
-            }
-            AT_LOG_INFO("Char: %#4x, SearchString: [%s]", ch, WStrToUTF8(g_SearchString).c_str());
-            update && SendMessageW(g_hSearchString, WM_SETTEXT, 0, (LPARAM)g_SearchString.c_str());
-#endif // 0
-        }
-        // AT_LOG_INFO("Not handled: wParam: %0#4x, iswprint: %d", wParam, iswprint((wint_t)wParam));
     } break;
 
     case WM_NOTIFY: {
         AT_LOG_INFO("WM_NOTIFY");
-        //LPNMHDR nmhdr = reinterpret_cast<LPNMHDR>(lParam);
-        //if (nmhdr->code == LVN_ITEMCHANGED) {
-        //    LPNMLISTVIEW pnmListView = reinterpret_cast<LPNMLISTVIEW>(nmhdr);
-
-        //    if ((pnmListView->uChanged & LVIF_STATE) && (pnmListView->uNewState & LVIS_SELECTED)) {
-        //        // The mouse has moved over the item
-        //        // You can show a message or perform any action here
-        //        MessageBox(hListView, L"Mouse moved over item!", L"ListView Notification", MB_OK | MB_ICONINFORMATION);
-        //    }
-        //}
     } break;
 
     case WM_MOUSEMOVE: {
-        //AT_LOG_INFO("WM_MOUSEMOVE");
-        // Track mouse leave event
         TRACKMOUSEEVENT tme;
-        tme.cbSize    = sizeof(tme);
-        tme.dwFlags   = TME_LEAVE;
+        tme.cbSize = sizeof(tme);
+        tme.dwFlags = TME_LEAVE;
         tme.hwndTrack = hListView;
         TrackMouseEvent(&tme);
     } break;
 
     case WM_MOUSELEAVE: {
-        //AT_LOG_INFO("WM_MOUSELEAVE");
-        // Hide the tooltip when the mouse leaves the ListView
         if (g_Settings.ShowProcessInfoTooltip) {
             HideCustomToolTip();
         }
 
-        // Reset the hovered item index and hot item index
         g_MouseHoverIndex = -1;
         g_nLVHotItem = -1;
-
-        // Invalidate the ListView to remove any highlighting
         InvalidateRect(hListView, nullptr, TRUE);
     } break;
 
-    // ----------------------------------------------------------------------------
-    // Owner draw item
-    // ----------------------------------------------------------------------------
     case WM_DRAWITEM: {
         LPDRAWITEMSTRUCT lpDrawItemStruct = (LPDRAWITEMSTRUCT)lParam;
         return AT::ATListViewDrawItem(hListView, lpDrawItemStruct);
@@ -1444,6 +1214,7 @@ LRESULT CALLBACK ListViewSubclassProc(
 
     return DefSubclassProc(hListView, uMsg, wParam, lParam);
 }
+
 
 void WindowResizeAndPosition(HWND hWnd, int wndWidth, int wndHeight) {
     // Get the dimensions of the screen

--- a/source/AltTabWindow.cpp
+++ b/source/AltTabWindow.cpp
@@ -633,7 +633,7 @@ HWND ShowAltTabWindow(HWND& hAltTabWnd, int direction) {
     tme.dwFlags   = TME_LEAVE;
     tme.hwndTrack = hAltTabWnd;
     TrackMouseEvent(&tme);
-
+    
     return hAltTabWnd;
 #endif // 0
 }
@@ -1006,9 +1006,9 @@ inline bool HandleCommonAltTabKeys(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
         return true;
     }
     // ----------------------------------------------------------------------------
-    // Backtick (VK_OEM_3)
+    // Backtick
     // ----------------------------------------------------------------------------
-    else if (vkCode == VK_OEM_3) { // 0xC0 - '`~' for US
+    else if (vkCode == AT_NON_BEEPING_SEARCH_KEY) {
         AT_LOG_INFO("Backtick Pressed!, g_IsAltBacktick = %d", g_IsAltBacktick);
         const int direction = isShiftPressed ? -1 : 1;
 
@@ -1105,13 +1105,13 @@ LRESULT CALLBACK SearchStringSubclassProc(
             }
             return commonResult;
         }
-
-        // Fallback processing for search character registration
+        
+           // Fallback processing for search character registration
         if ((g_IsAltTab || g_IsAltBacktick) && !g_IsAltCtrlTab) {
             wchar_t ch = '\0';
             const bool isChar = ATMapVirtualKey((UINT)wParam, ch);
             bool update = false;
-            if (isChar && !(wParam == '`' || wParam == VK_DELETE || wParam == VK_TAB || ch == '\0')) {
+            if (isChar && !(wParam == g_Settings.HKBacktickKey)) {
                 g_SearchString += ch;
                 update = true;
             } else if (wParam == VK_BACK && !g_SearchString.empty()) {
@@ -2230,7 +2230,7 @@ INT_PTR CALLBACK ATAboutDlgProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM l
         SetWindowLong(hDlg, GWL_EXSTYLE, GetWindowLong(hDlg, GWL_EXSTYLE) | WS_EX_APPWINDOW);
 
         std::wstring productInfo = std::format(L"<a href=\"{}\">{}</a> v{}", AT_PRODUCT_PAGE, AT_PRODUCT_NAMEW, AT_VERSION_TEXTW);
-        std::wstring copyright   = std::format(L"Copyright © {} <a href=\"{}\">{}</a>", AT_PRODUCT_YEARW, AT_PRODUCT_PAGE, AT_AUTHOR_NAME);
+        std::wstring copyright   = std::format(L"Copyright \u00A9 {} <a href=\"{}\">{}</a>", AT_PRODUCT_YEARW, AT_PRODUCT_PAGE, AT_AUTHOR_NAME);
 
         SetDlgItemTextW(hDlg, IDC_SYSLINK_ABOUT_PRODUCT_NAME, productInfo.c_str());
         SetDlgItemTextW(hDlg, IDC_SYSLINK_ABOUT_COPYRIGHT   , copyright.c_str());


### PR DESCRIPTION
Fix for #7 and fix for https://github.com/lokeshgovindu/AltTab/issues/3#issuecomment-2860623599.

I couldn't find the "right" way to fix the beep caused when VK_OEM_3, is posted to `g_hListView` so I used an unused keycode I defined as `AT_NON_BEEPING_SEARCH_KEY` to send the "backtick" message, and that doesn't beep:
```C
                if (vkCode == g_Settings.HKBacktickKey) {
                    // AT_LOG_INFO("Backtick Pressed!");
                    PostMessage(g_hListView, WM_KEYDOWN, AT_NON_BEEPING_SEARCH_KEY, 0); 
                    return TRUE;
                }
```

Users can change the "backtick" button if they want (like [this person](https://github.com/lokeshgovindu/AltTab/issues/3#issuecomment-2860623599) , although I didn't create a UI for it I just updated the configuration file:
```ini
[Hotkeys]
AltTabEnabled=1
AltBacktickEnabled=1
AltCtrlTabEnabled=1
BacktickKey=0xC0
...
;   4. BacktickKey: Is the hex value of a virtual key code, as defined here:
;      https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
;      You might like to try: 0xC0 (VK_OEM_3) for US Keyboard
;                             0xDC (VK_OEM_5) for Italian Keyboard
;                             0xDE (VK_OEM_7) for French Keyboard
```
This pull request also includes the [duplicated code PR](https://github.com/lokeshgovindu/AltTab/pull/36). Sorry if that's a problem for you.

I also had to change the copyright symbol, because it was corrupted for some reason


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now configure the Backtick hotkey using a saved setting value.
  * Keyboard shortcuts in the AltTab interface now behave more consistently across the search and list views.

* **Bug Fixes**
  * Fixed the Backtick action so it no longer triggers the Windows beep in supported cases.
  * Corrected the copyright symbol display in the About dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->