### PR TITLE
Backtick configurable

### DIFF
--- a/source/AltTab.cpp
+++ b/source/AltTab.cpp
@@ -469,7 +469,8 @@ LRESULT CALLBACK LLKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
                 // ----------------------------------------------------------------------------
                 // Alt + Backtick
                 // ----------------------------------------------------------------------------
-                else if (g_Settings.HKAltBacktickEnabled && vkCode == VK_OEM_3) { // 0xC0
+                else if (g_Settings.HKAltBacktickEnabled && vkCode == g_Settings.HKBacktickKey) {
+
                     g_IsAltTab      = false;
                     g_IsAltBacktick = true;
 
@@ -558,7 +559,7 @@ LRESULT CALLBACK LLKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
                 // gets opened.
                 //
                 // Now, send WM_KEYDOWN to g_hAltTabWnd, there handle.
-                if (vkCode == VK_OEM_3) { // 0xC0
+                if (vkCode == g_Settings.HKBacktickKey) {
                     //AT_LOG_INFO("Backtick Pressed!");
                     PostMessage(g_hListView, WM_KEYDOWN, vkCode, 0);
                     return TRUE;

--- a/source/AltTabSettings.cpp
+++ b/source/AltTabSettings.cpp
@@ -35,6 +35,7 @@ void ATSettingsInitDialog(HWND hDlg, const AltTabSettings& settings);
 void ATReadSettingsFromUI(HWND hDlg, AltTabSettings& settings);
 void AddTooltips         (HWND hDlg);
 void ATLogSettings       (const AltTabSettings& settings);
+int64_t HexToDecimal(const std::wstring& hexStr);
 
 namespace {
     // Sections
@@ -72,6 +73,7 @@ namespace {
     const wchar_t* ALTTAB_ENABLED            = L"AltTabEnabled"           ;
     const wchar_t* ALTBACKTICK_ENABLED       = L"AltBacktickEnabled"      ;
     const wchar_t* ALTCTRLTAB_ENABLED        = L"AltCtrlTabEnabled"       ;
+    const wchar_t* BACKTICK_KEY              = L"BacktickKey";
     const wchar_t* SIMILAR_PROCESS_GROUPS    = L"SimilarProcessGroups"    ;
     const wchar_t* ENABLED                   = L"Enabled"                 ;
     const wchar_t* PROCESS_LIST              = L"ProcessList"             ;
@@ -109,6 +111,7 @@ void AltTabSettings::Reset() {
     HKAltTabEnabled            = DEFAULT_ALT_TAB_ENABLED            ;
     HKAltBacktickEnabled       = DEFAULT_ALT_BACKTICK_ENABLED       ;
     HKAltCtrlTabEnabled        = DEFAULT_ALT_CTRL_TAB_ENABLED       ;
+    HKBacktickKey              = HexToDecimal(DEFAULT_BACKTICK_KEY);
     SSCueBannerText            = DEFAULT_SS_CUE_BANNER_TEXT         ;
     SSFontName                 = DEFAULT_SS_FONT_NAME               ;
     SSFontSize                 = DEFAULT_SS_FONT_SIZE               ;
@@ -479,9 +482,14 @@ std::wstring ATSettingsFilePath(bool overwrite) {
         fs << ";        0xBB : Green component"                                                 << std::endl;
         fs << ";        0xCC : Blue component"                                                  << std::endl;
         fs << ";   3. FontStyle: normal / italic / bold / bold italic"                          << std::endl;
-        fs << ";   4. Please delete this file to create a new settings file when AltTab opens." << std::endl;
-        fs << ";   5. Please use tray menu Reload AltTabSettings.ini / Reload in Settings"      << std::endl;
-        fs << ";      dialog to make use of new settings without restarting AltTab."            << std::endl;
+        fs << ";   4. BacktickKey: Is the hex value of a virtual key code, as defined here:" << std::endl;
+        fs << ";      https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes" << std::endl;
+        fs << ";      You might like to try: 0xC0 (VK_OEM_3) for US Keyboard" << std::endl;
+        fs << ";                             0xDC (VK_OEM_5) for Italian Keyboard" << std::endl;
+        fs << ";                             0xDE (VK_OEM_7) for French Keyboard" << std::endl;
+        fs << ";   5. Please delete this file to create a new settings file when AltTab opens." << std::endl;
+        fs << ";   6. Please use tray menu Reload AltTabSettings.ini / Reload in Settings" << std::endl;
+        fs << ";      dialog to make use of new settings without restarting AltTab." << std::endl;
         fs << "; -----------------------------------------------------------------------------" << std::endl;
         fs.close();
         ATSettingsToFile(settingsFilePath.wstring());
@@ -511,6 +519,32 @@ void ReadSetting(const std::wstring& iniFile, LPCTSTR section, LPCTSTR keyName, 
     GetPrivateProfileStringW(section, keyName, defaultValue, buffer, bufferSize, iniFile.c_str());
     value = buffer;
 }
+int64_t HexToDecimal(const std::wstring& hexStr) {
+    std::wregex hexRegex(L"^(0[xX])?[0-9a-fA-F]+$");
+    if (!std::regex_match(hexStr, hexRegex)) {
+        AT_LOG_DEBUG("%S does not seem to be a hex value", hexStr.c_str());
+        return 0;
+    }
+
+    const wchar_t* str = hexStr.c_str();
+
+    // Skip "0x" or "0X" prefix if present
+    if (hexStr.length() >= 2 && str[0] == L'0' && (str[1] == L'x' || str[1] == L'X')) {
+        str += 2;
+    }
+
+    wchar_t* endPtr = nullptr;
+    uint64_t value = wcstoull(str, &endPtr, 16);
+
+    return value;
+}
+
+const wchar_t* DecimalToHex(uint64_t decimal) {
+    static wchar_t buffer[32];
+    swprintf_s(buffer, L"0x%llX", decimal);
+    return buffer;
+}
+
 
 /*!
  * \brief Write the current settings the given file path
@@ -525,10 +559,13 @@ void ATSettingsToFile(const std::wstring& iniFile) {
     const std::wstring LVBackgroundColor          = ColorRefToRGBString(g_Settings.LVBackgroundColor         );
     const std::wstring LVHighlightTextColor       = ColorRefToRGBString(g_Settings.LVHighlightTextColor      );
     const std::wstring LVHighlightBackgroundColor = ColorRefToRGBString(g_Settings.LVHighlightBackgroundColor);
+    const std::wstring HKBacktickKeyHex = DecimalToHex(g_Settings.HKBacktickKey);
 
     WriteSetting(iniFile, HOTKEYS           , ALTTAB_ENABLED           , g_Settings.HKAltTabEnabled         );
     WriteSetting(iniFile, HOTKEYS           , ALTBACKTICK_ENABLED      , g_Settings.HKAltBacktickEnabled    );
     WriteSetting(iniFile, HOTKEYS           , ALTCTRLTAB_ENABLED       , g_Settings.HKAltCtrlTabEnabled     );
+    WriteSetting(iniFile, HOTKEYS           , BACKTICK_KEY             , HKBacktickKeyHex);
+
     WriteSetting(iniFile, SEARCH_STRING     , CUE_BANNER_TEXT          , g_Settings.SSCueBannerText         );
     WriteSetting(iniFile, SEARCH_STRING     , FONT_NAME                , g_Settings.SSFontName              );
     WriteSetting(iniFile, SEARCH_STRING     , FONT_SIZE                , g_Settings.SSFontSize              );
@@ -574,10 +611,14 @@ void ATLoadSettings() {
     DWORD LVBackgroundColor          = 0;
     DWORD LVHighlightTextColor       = 0;
     DWORD LVHighlightBackgroundColor = 0;
+    std::wstring HKBacktickKeyHex;
 
+    // Setting default values here seems a bit silly if we can just call `g_Settings.Reset();` instead. That way
+    // defaults are in one place.
     ReadSetting(iniFile, HOTKEYS           , ALTTAB_ENABLED           , DEFAULT_ALT_TAB_ENABLED            , g_Settings.HKAltTabEnabled         );
     ReadSetting(iniFile, HOTKEYS           , ALTBACKTICK_ENABLED      , DEFAULT_ALT_BACKTICK_ENABLED       , g_Settings.HKAltBacktickEnabled    );
     ReadSetting(iniFile, HOTKEYS           , ALTCTRLTAB_ENABLED       , DEFAULT_ALT_CTRL_TAB_ENABLED       , g_Settings.HKAltCtrlTabEnabled     );
+    ReadSetting(iniFile, HOTKEYS           , BACKTICK_KEY             , DEFAULT_BACKTICK_KEY               , HKBacktickKeyHex);
     ReadSetting(iniFile, SEARCH_STRING     , CUE_BANNER_TEXT          , DEFAULT_SS_CUE_BANNER_TEXT         , g_Settings.SSCueBannerText         );
     ReadSetting(iniFile, SEARCH_STRING     , FONT_NAME                , DEFAULT_SS_FONT_NAME               , g_Settings.SSFontName              );
     ReadSetting(iniFile, SEARCH_STRING     , FONT_SIZE                , DEFAULT_SS_FONT_SIZE               , g_Settings.SSFontSize              );
@@ -615,7 +656,15 @@ void ATLoadSettings() {
     g_Settings.LVBackgroundColor          = RGBIntToColorRef(LVBackgroundColor         );
     g_Settings.LVHighlightTextColor       = RGBIntToColorRef(LVHighlightTextColor      );
     g_Settings.LVHighlightBackgroundColor = RGBIntToColorRef(LVHighlightBackgroundColor);
-
+    g_Settings.HKBacktickKey              = HexToDecimal(HKBacktickKeyHex);
+    if (g_Settings.HKBacktickKey == 0) {
+        AT_LOG_WARN(
+            "%ls=%ls is not valid hex. Defaulting to %ls",
+            BACKTICK_KEY,
+            HKBacktickKeyHex.c_str(),
+            DEFAULT_BACKTICK_KEY);
+        g_Settings.HKBacktickKey = HexToDecimal(DEFAULT_BACKTICK_KEY);
+    }
     // Clear the previous ProcessGroupsList
     g_Settings.ProcessGroupsList.clear();
 

--- a/source/AltTabSettings.cpp
+++ b/source/AltTabSettings.cpp
@@ -887,6 +887,7 @@ void ATSettingsInitDialog(HWND hDlg, const AltTabSettings& settings) {
     SetDlgItemText    (hDlg, IDC_EDIT_SS_BANNER_TEXT          , settings.SSCueBannerText.c_str()     );
     SetDlgItemText    (hDlg, IDC_EDIT_SIMILAR_PROCESS_GROUPS  , settings.SimilarProcessGroups.c_str());
  
+    // TODO: Probably not cleaned up
     HFONT    hFont     = CreateFontW(14, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
                                      DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
                                      DEFAULT_QUALITY, DEFAULT_PITCH | FF_SWISS, L"Lucida Console");
@@ -960,6 +961,8 @@ void ATSettingsInitDialog(HWND hDlg, const AltTabSettings& settings) {
     LOGFONT lf = {};
     GetObjectW(hBoldFont, sizeof(LOGFONT), &lf);
     lf.lfWeight = FW_BOLD;
+
+    // TODO: Probably not cleaned up
     hBoldFont = CreateFontIndirectW(&lf);
 
     SendMessageW(GetDlgItem(hDlg, IDC_GROUPBOX_STORAGE           ), WM_SETFONT, (WPARAM)hBoldFont, TRUE);

--- a/source/AltTabSettings.h
+++ b/source/AltTabSettings.h
@@ -22,6 +22,7 @@ using StringList           = std::vector<std::wstring>;
 #define DEFAULT_ALT_TAB_ENABLED              true
 #define DEFAULT_ALT_BACKTICK_ENABLED         true
 #define DEFAULT_ALT_CTRL_TAB_ENABLED         true
+#define DEFAULT_BACKTICK_KEY                 L"0xC0"   // aka VK_OEM_3, US `~ key
 #define DEFAULT_SS_CUE_BANNER_TEXT           L"Search windows by title or process name..."
 #define DEFAULT_SS_FONT_NAME                 L"Lucida Handwriting"
 #define DEFAULT_SS_FONT_SIZE                 11
@@ -72,6 +73,7 @@ struct AltTabSettings {
     bool                   HKAltTabEnabled;            // Alt+Tab enabled
     bool                   HKAltBacktickEnabled;       // Alt+Backtick enabled
     bool                   HKAltCtrlTabEnabled;        // Alt+Ctrl+Tab enabled
+    WPARAM                 HKBacktickKey;              // What key is the 'backtick' key
     // ----------------------------------------------------------------------------
     // SearchString Font Name, Size, Style, Color and Background Color
     // ----------------------------------------------------------------------------

--- a/source/AltTabWindow.cpp
+++ b/source/AltTabWindow.cpp
@@ -197,9 +197,10 @@ namespace AT {
             GetTextExtentPointW(hdc, matchText, matchTextLen, &matchSize);
             RECT matchRect = rci;
             matchRect.right = AT_MIN(matchRect.right, matchRect.left + matchSize.cx);
-
             HBRUSH hbr = CreateSolidBrush(g_Settings.LVHighlightBackgroundColor);
             FillRect(hdc, &matchRect, hbr);
+            DeleteObject(hbr);
+            
             SetTextColor(hdc, g_Settings.LVHighlightTextColor);
             DrawTextW(hdc, matchText, matchTextLen, &matchRect, format);
 
@@ -669,6 +670,17 @@ void RefreshAltTabWindow() {
     // But the icons in the ImageList are drawn using the ImageList g_hLVImageList.
     HIMAGELIST hImageListDummy = ImageList_Create(imageWidth, imageHeight + 1, ILC_COLOR32 | ILC_MASK, 0, 1);
     HIMAGELIST hImageList = ImageList_Create(imageWidth, imageHeight, ILC_COLOR32 | ILC_MASK, 0, 1);
+
+     //Destroy old image lists first
+    if (g_hLVImageList) {
+        ImageList_Destroy(g_hLVImageList);
+        g_hLVImageList = nullptr;
+    }
+    // Also need to destroy the old dummy image list
+    HIMAGELIST hOldDummy = ListView_GetImageList(g_hListView, LVSIL_SMALL);
+    if (hOldDummy) {
+        ImageList_Destroy(hOldDummy);
+    }
 
     for (const auto& item : g_AltTabWindows) {
         ImageList_AddIcon(hImageList, item.hIcon);
@@ -1959,12 +1971,15 @@ bool IsExcludedProcess(const std::wstring& processName) {
 // AltTab window procedure handlers
 // ----------------------------------------------------------------------------
 
+DWORD prevGdiObjectCount = 0;
+DWORD prevUserObjectCount = 0;
+
 BOOL ATW_OnCreate(HWND hWnd, LPCREATESTRUCT /*lpCreateStruct*/) {
     AT_LOG_TRACE;
 
     g_hAltTabWnd = hWnd;
     AT_LOG_INFO("AltTab Window Handle: [%#08X]", g_hAltTabWnd);
-
+    
     // Get screen width and height
     const int screenWidth  = GetSystemMetrics(SM_CXSCREEN);
     const int screenHeight = GetSystemMetrics(SM_CYSCREEN);
@@ -1987,9 +2002,14 @@ BOOL ATW_OnCreate(HWND hWnd, LPCREATESTRUCT /*lpCreateStruct*/) {
     // Calculate the required height for the static control based on font size
     HDC hdc = GetDC(hWnd);
 
-    g_hSSFont = CreateFontEx(hdc, g_Settings.SSFontName, g_Settings.SSFontSize, g_Settings.SSFontStyle);
-    g_hLVFont = CreateFontEx(hdc, g_Settings.LVFontName, g_Settings.LVFontSize, g_Settings.LVFontStyle);
-
+    // TODO: Handle changes to font in settings file.
+    if (g_hSSFont == nullptr) {
+        g_hSSFont = CreateFontEx(hdc, g_Settings.SSFontName, g_Settings.SSFontSize, g_Settings.SSFontStyle);
+    }
+    if (g_hLVFont == nullptr) {
+        g_hLVFont = CreateFontEx(hdc, g_Settings.LVFontName, g_Settings.LVFontSize, g_Settings.LVFontStyle);
+    }
+    
     SelectObject(hdc, g_hSSFont);
 
     TEXTMETRIC tm;
@@ -2038,7 +2058,7 @@ BOOL ATW_OnCreate(HWND hWnd, LPCREATESTRUCT /*lpCreateStruct*/) {
 
     // Subclass the edit control
     SetWindowSubclass(hSearchString, SearchStringSubclassProc, 1, 0);
-
+ 
     // Here adding 1 pixel to the Y position to avoid the static text control overlap with the ListView control
     if (g_Settings.ShowSearchString) {
         Y += searchStringHeight;
@@ -2094,46 +2114,7 @@ BOOL ATW_OnCreate(HWND hWnd, LPCREATESTRUCT /*lpCreateStruct*/) {
     SetWindowLong(hWnd, GWL_EXSTYLE, GetWindowLong(hWnd, GWL_EXSTYLE) | WS_EX_LAYERED);
     SetLayeredWindowAttributes(hWnd, RGB(255, 255, 255), (BYTE)g_Settings.Transparency, LWA_ALPHA);
 
-    // std::vector<AltTabWindowData> altTabWindows;
-    EnumWindows(EnumWindowsProc, (LPARAM)(&g_AltTabWindows));
-    AT_LOG_INFO("g_AltTabWindows.size() : %d", g_AltTabWindows.size());
-
-    // Identify the processes which are running from different paths
-    std::unordered_map<std::wstring, std::unordered_set<std::wstring>> processMap;
-    for (const auto& item : g_AltTabWindows) {
-        const std::wstring key = item.ProcessName + item.Title;
-        processMap[key].insert(item.FullPath);
-    }
-    for (auto& item : g_AltTabWindows) {
-        const std::wstring key = item.ProcessName + item.Title;
-        if (processMap[key].size() > 1) {
-            item.IsConflictProcess = true;
-        }
-    }
-
-    // Create ImageList and add icons
-    const int imageWidth = GetSystemMetrics(SM_CXICON);
-    const int imageHeight = GetSystemMetrics(SM_CYICON);
-
-    // Create ImageList and add icons, assign a dummy ImageList to set the row height
-    // The row height is determined by the height of the icons in the ImageList assigned as LVSIL_SMALL
-    // But the icons in the ImageList are drawn using the ImageList g_hLVImageList.
-    HIMAGELIST hImageListDummy = ImageList_Create(imageWidth, imageHeight + 1, ILC_COLOR32 | ILC_MASK, 0, 1);
-    HIMAGELIST hImageList = ImageList_Create(imageWidth, imageHeight, ILC_COLOR32 | ILC_MASK, 0, 1);
-
-    for (const auto& item : g_AltTabWindows) {
-        ImageList_AddIcon(hImageList, item.hIcon);
-    }
-
-    // Set the ImageList for the ListView
-    // Assign as the small image list (LVSIL_SMALL affects row height)
-    ListView_SetImageList(hListView, hImageListDummy, LVSIL_SMALL);
-    g_hLVImageList = hImageList;
-
-    // Add windows to ListView
-    for (int i = 0; i < g_AltTabWindows.size(); ++i) {
-        AddListViewItem(hListView, i, g_AltTabWindows[i]);
-    }
+    RefreshAltTabWindow();
 
     // Compute the required height and resize the ListView
     // Get the header control associated with the ListView
@@ -2173,7 +2154,7 @@ BOOL ATW_OnCreate(HWND hWnd, LPCREATESTRUCT /*lpCreateStruct*/) {
 
     SetForegroundWindow(hWnd);
     SetFocus(hSearchString);
-
+ 
     // Select the first row
     LVITEM lvItem;
     lvItem.stateMask = LVIS_FOCUSED | LVIS_SELECTED;
@@ -2182,18 +2163,33 @@ BOOL ATW_OnCreate(HWND hWnd, LPCREATESTRUCT /*lpCreateStruct*/) {
 
     // Create a timer to refresh the ListView when there is a change in windows
     SetTimer(hWnd, TIMER_WINDOW_COUNT, TIMER_WINDOW_COUNT_ELAPSE, nullptr);
-
+   
     return TRUE;
+}
+
+
+HBRUSH g_hSSBackgroundBrush = NULL;
+COLORREF g_cachedSSBackgroundColor = 0xFFFFFFFF;
+
+LRESULT ATW_HandleSearchControlColors(HDC hDC, COLORREF textColor, COLORREF bgColor) {
+    SetTextColor(hDC, textColor);
+    SetBkColor(hDC, bgColor);
+
+    if (bgColor != g_cachedSSBackgroundColor || !g_hSSBackgroundBrush) {
+        if (g_hSSBackgroundBrush) {
+            DeleteObject(g_hSSBackgroundBrush);
+        }
+        g_hSSBackgroundBrush = CreateSolidBrush(bgColor);
+        g_cachedSSBackgroundColor = bgColor;
+    }
+
+    return (INT_PTR)g_hSSBackgroundBrush;
 }
 
 LRESULT ATW_OnCtlColorEdit(HWND hWnd, HDC hDC, HWND hCtl, UINT /*type*/) {
     AT_LOG_TRACE;
     if (hCtl == g_hSearchString) {
-        // Set the text color and background color of the edit control
-        SetTextColor(hDC, g_Settings.SSFontColor);
-        SetBkColor(hDC, g_Settings.SSBackgroundColor);
-
-        return (INT_PTR)CreateSolidBrush(g_Settings.SSBackgroundColor);
+        return ATW_HandleSearchControlColors(hDC, g_Settings.SSFontColor, g_Settings.SSBackgroundColor);
     }
     return DefWindowProc(hWnd, WM_CTLCOLOREDIT, (WPARAM)hDC, (LPARAM)hCtl);
 }
@@ -2201,11 +2197,7 @@ LRESULT ATW_OnCtlColorEdit(HWND hWnd, HDC hDC, HWND hCtl, UINT /*type*/) {
 LRESULT ATW_OnCtlColorStatic(HWND hWnd, HDC hDC, HWND hCtl, UINT /*type*/) {
     AT_LOG_TRACE;
     if (hCtl == g_hSearchString) {
-        // Set the text color and background color of the static text control
-        SetTextColor(hDC, g_Settings.SSFontColor);
-        SetBkColor(hDC, g_Settings.SSBackgroundColor);
-
-        return (INT_PTR)CreateSolidBrush(g_Settings.SSBackgroundColor);
+        return ATW_HandleSearchControlColors(hDC, g_Settings.SSFontColor, g_Settings.SSBackgroundColor);
     }
     return DefWindowProc(hWnd, WM_CTLCOLORSTATIC, (WPARAM)hDC, (LPARAM)hCtl);
 }
@@ -2238,6 +2230,7 @@ void ATW_OnSysCommand(HWND hwnd, UINT cmd, int x, int y) {
 void ATW_OnClose(HWND /*hwnd*/) {
     AT_LOG_TRACE;
 
+    // TODO: Never called?
     // Release the fonts
     if (g_hLVFont != nullptr) {
         DeleteObject(g_hLVFont);
@@ -2491,6 +2484,12 @@ INT_PTR CALLBACK ATAboutDlgProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM l
     case WM_DESTROY:
         DestroyIcon((HICON)SendMessageW(hDlg, WM_GETICON, ICON_SMALL, 0));
         DestroyIcon((HICON)SendMessageW(hDlg, WM_GETICON, ICON_BIG, 0));
+        
+        // Clean up the cached brush
+        if (g_hSSBackgroundBrush) {
+            DeleteObject(g_hSSBackgroundBrush);
+            g_hSSBackgroundBrush = NULL;
+        }
         break;
     }
     return (INT_PTR)FALSE;

--- a/source/AltTabWindow.cpp
+++ b/source/AltTabWindow.cpp
@@ -1020,7 +1020,7 @@ LRESULT CALLBACK SearchStringSubclassProc(
         // ----------------------------------------------------------------------------
         // Backtick
         // ----------------------------------------------------------------------------
-        else if (vkCode == VK_OEM_3) { // 0xC0 - '`~' for US
+        else if (vkCode == g_Settings.HKBacktickKey) { // 0xC0 - '`~' for US
             AT_LOG_INFO("Backtick Pressed!, g_IsAltBacktick = %d", g_IsAltBacktick);
             const int direction = isShiftPressed ? -1 : 1;
 
@@ -1300,7 +1300,7 @@ LRESULT CALLBACK ListViewSubclassProc(
         // ----------------------------------------------------------------------------
         // Backtick
         // ----------------------------------------------------------------------------
-        else if (vkCode == VK_OEM_3) { // 0xC0 - '`~' for US
+        else if (vkCode == g_Settings.HKBacktickKey) { // 0xC0 - '`~' for US
             AT_LOG_INFO("Backtick Pressed!, g_IsAltBacktick = %d", g_IsAltBacktick);
             const int direction = isShiftPressed ? -1 : 1;
 


### PR DESCRIPTION
Users can change the "backtick" button if they want (like [this person](https://github.com/lokeshgovindu/AltTab/issues/3#issuecomment-2860623599) , although I didn't create a UI for it I just updated the configuration file:
```ini
[Hotkeys]
AltTabEnabled=1
AltBacktickEnabled=1
AltCtrlTabEnabled=1
BacktickKey=0xC0
...
;   4. BacktickKey: Is the hex value of a virtual key code, as defined here:
;      https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
;      You might like to try: 0xC0 (VK_OEM_3) for US Keyboard
;                             0xDC (VK_OEM_5) for Italian Keyboard
;                             0xDE (VK_OEM_7) for French Keyboard
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The backtick shortcut now follows your configured hotkey instead of a fixed key.
  * Backtick key settings are now saved and restored between app launches.

* **Bug Fixes**
  * Fixed resource leaks that could build up during window updates and redraws.
  * Improved keyboard handling so the Alt+Backtick behavior stays consistent with your chosen key.
  * Reduced unnecessary recreation of fonts and other UI resources for smoother refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->